### PR TITLE
Removes empty lines

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -10,5 +10,5 @@ curl -A "User-Agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/201
 | xargs curl -s -L \
 | gunzip \
 | egrep -v '^#' \
+| sed "/^$/d" \
 | gzip - > /tmp/bt_blocklists.gz
-


### PR DESCRIPTION
This patch aims to silence "blocklist skipped invalid address at line 1" warning log.

---

Feel free to ignore/edit this as you want @Naunter.
Bye 👋
